### PR TITLE
Communicate with Ollama server outside the docker container

### DIFF
--- a/app/llm-poc-variant-01/.gitignore
+++ b/app/llm-poc-variant-01/.gitignore
@@ -1,2 +1,3 @@
 source_documents
 vector_db
+.python-version

--- a/app/llm-poc-variant-01/docker/run-docker-container.sh
+++ b/app/llm-poc-variant-01/docker/run-docker-container.sh
@@ -21,11 +21,13 @@ OLLAMA_VOLUME_SHARED="--volume $(which ollama):/usr/bin/ollama"
 HF_CACHE_SHARED="--volume ${LOCAL_MODEL_FOLDER}/.cache:/root/.cache"
 
 set -x
-pullImage
+# pullImage
 time docker run --rm -it                   \
                 --platform="linux/amd64"   \
                 --network="host"           \
+                --add-host=host.docker.internal:host-gateway \
                 --workdir "${WORKDIR}"     \
+                --env OLLAMA_HOST="http://host.docker.internal:11434" \
                 ${HF_CACHE_SHARED}         \
                 ${MODEL_VOLUME_SHARED}     \
                 ${OLLAMA_VOLUME_SHARED}    \

--- a/app/llm-poc-variant-01/lpiGPT.py
+++ b/app/llm-poc-variant-01/lpiGPT.py
@@ -13,6 +13,8 @@ from datetime import datetime
 
 from constants import CHROMA_SETTINGS
 
+OLLAMA_HOST = os.getenv('OLLAMA_HOST')
+
 def main():
 
     IS_GPU_AVAILABLE = torch.cuda.is_available()
@@ -50,7 +52,7 @@ def main():
     # activate/deactivate the streaming StdOut callback for LLMs
     callbacks = [] if args.mute_stream else [StreamingStdOutCallbackHandler()]
 
-    llm = Ollama(model=args.chat_model, callbacks=callbacks)
+    llm = Ollama(model=args.chat_model, callbacks=callbacks, base_url=OLLAMA_HOST)
 
     qa = RetrievalQA.from_chain_type(
         llm=llm,


### PR DESCRIPTION
Adapting shellscript to pass the OLLAMA_HOST into the docker container to use it inside the python code - to communicate with the Ollama server outside the docker container